### PR TITLE
fixing date issues with dashboard

### DIFF
--- a/src/app/page-analytics/[...pagefilter]/page-client.tsx
+++ b/src/app/page-analytics/[...pagefilter]/page-client.tsx
@@ -42,6 +42,7 @@ export default function PageAnalyticsClient({
   dateRange,
   pagePath,
 }: PageAnalyticsClientProps) {
+  console.log('dateRange', dateRange);
   return (
     <SidebarProvider>
       <AppSidebar />

--- a/src/app/page-analytics/[...pagefilter]/page.tsx
+++ b/src/app/page-analytics/[...pagefilter]/page.tsx
@@ -12,6 +12,7 @@ function getLastMonthDateRange(): { startDate: string; endDate: string } {
   const endDate = new Date();
   const startDate = new Date();
   startDate.setDate(startDate.getDate() - 30);
+  console.log('startDate:', startDate, 'endDate:', endDate);
   return {
     startDate: startDate.toISOString().split('T')[0],
     endDate: endDate.toISOString().split('T')[0],
@@ -168,9 +169,9 @@ export default async function Page({ params }: { params: { pagefilter: string[] 
 
   // --- Process Data ---
   const pageTitle = scrollData[0]?.page_title || `Analytics: ${parsedPagePath}`;
-  const dateRangeText = ` (${new Date(startDate).toLocaleDateString()} - ${new Date(
-    endDate,
-  ).toLocaleDateString()})`;
+  const dateRangeText = ` (${new Date(
+    `${startDate}T12:00:00Z`,
+  ).toLocaleDateString()} - ${new Date(`${endDate}T12:00:00Z`).toLocaleDateString()})`;
 
   // --- Render Client Component ---
   return (

--- a/src/components/charts/scroll-filters.tsx
+++ b/src/components/charts/scroll-filters.tsx
@@ -33,9 +33,9 @@ export function ScrollFilters({
   const router = useRouter();
   const [showDatePicker, setShowDatePicker] = useState(false);
 
-  // Set default dates from props
-  const defaultStartDate = new Date(initialDateRange.startDate);
-  const defaultEndDate = new Date(initialDateRange.endDate);
+  // Set default dates from props with timezone adjustment
+  const defaultStartDate = new Date(`${initialDateRange.startDate}T12:00:00Z`);
+  const defaultEndDate = new Date(`${initialDateRange.endDate}T12:00:00Z`);
 
   // Initialize date range state
   const [dateRange, setDateRange] = useState([
@@ -71,6 +71,7 @@ export function ScrollFilters({
     if (page === '/') {
       page = '_root';
     }
+    console.log('page', page);
     const startDateStr = format(startDate, 'yyyy-MM-dd');
     const endDateStr = format(endDate, 'yyyy-MM-dd');
     const newPath = `/page-analytics/${page}/${startDateStr}/${endDateStr}`;
@@ -80,7 +81,7 @@ export function ScrollFilters({
   // Handle date range apply
   const handleApplyDateRange = () => {
     if (!dateRange[0]?.startDate || !dateRange[0]?.endDate) return;
-    updateUrl('', dateRange[0].startDate, dateRange[0].endDate);
+    updateUrl(pagePath, dateRange[0].startDate, dateRange[0].endDate);
     setShowDatePicker(false);
   };
 


### PR DESCRIPTION
This pull request includes updates to improve date handling by adding timezone adjustments, debugging logs, and a minor fix for URL updates. Below is a breakdown of the most important changes:

### Improvements to Date Handling:
* Adjusted date parsing to include a fixed timezone (`T12:00:00Z`) when creating `Date` objects to ensure consistent date handling across timezones. This change was applied in `src/app/page-analytics/[...pagefilter]/page.tsx` and `src/components/charts/scroll-filters.tsx`. ([src/app/page-analytics/[...pagefilter]/page.tsxL171-R174](diffhunk://#diff-182e11c1890b28d27d28a9d3fad5e8d5f2e9e30643a78d0baefb3b60817c2c6aL171-R174), [src/components/charts/scroll-filters.tsxL36-R38](diffhunk://#diff-57491c84e57ff4e62066586a040082abc80d8349d91a2d1adac71113346c367eL36-R38))

### Debugging Additions:
* Added `console.log` statements for debugging purposes:
  - Logging `dateRange` in `PageAnalyticsClient` to track the date range passed as a prop. ([src/app/page-analytics/[...pagefilter]/page-client.tsxR45](diffhunk://#diff-01d26c002186de296afdfe5bf7a59fefa63ec0c1c68e97bbac5a595f8ca07ffaR45))
  - Logging `startDate` and `endDate` in `getLastMonthDateRange` to verify the calculated date range. ([src/app/page-analytics/[...pagefilter]/page.tsxR15](diffhunk://#diff-182e11c1890b28d27d28a9d3fad5e8d5f2e9e30643a78d0baefb3b60817c2c6aR15))
  - Logging the `page` variable in `ScrollFilters` to debug the page path during URL updates.

### Minor Fixes:
* Updated the `updateUrl` function call in `ScrollFilters` to include the `pagePath` parameter instead of an empty string, ensuring the correct page path is used when applying a new date range.